### PR TITLE
Move content from community repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
 # <img src="https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png" alt="OpenTelemetry Icon" width="45" height=""> OpenTelemetry End-User SIG
+
+## What is the End-User SIG?
+
+There are two primary goals of the End-User SIG:
+* Foster a sense of vendor-agnostic community for OpenTelemetry end-users to promote learning and adoption. We currently accomplish this through: CNCF Slack channel, panels and blog posts.
+* Facilitate the collection and communication of end-user feedback to OpenTelemetry project special interest groups to influence SIG priorities. We currently accomplish this through: creation and maintenance of end-user research assets such as OpenTelemetry Community surveys & Organization and facilitation of structured end-user interview sessions.
+
+Our group discourages promotion of vendor-specific solutions and desires to keep the focus on OpenTelemetry core technologies, adoption and usage.
+
+## Get Involved
+
+There are many ways to get involved in our work! We (End-User SIG) meet every two weeks on Thursdays at 10:00 AM PST. Check out the [OpenTelemetry community calendar](https://calendar.google.com/calendar/embed?src=google.com_b79e3e90j7bbsa2n2p5an5lf60%40group.calendar.google.com)
+for the Zoom link and any updates to this schedule.
+
+Meeting notes are available as a [public Google doc](https://docs.google.com/document/d/1e-UNZA3Tuno9b53RQbe--whUcO0VIXF3P81oXsrBK6g). If you have trouble accessing the doc, please get in touch on [Slack](https://cloud-native.slack.com/archives/C01RT3MSWGZ).
+
+As an end user, you may want to:
+
+* Reach out to us to tell us your OpenTelemetry adoption story. You can reach out in [#otel-sig-end-user](https://cloud-native.slack.com/archives/C01RT3MSWGZ) to learn more.
+* Take one of our surveys, like our [OpenTelemetry Quarterly Feedback Survey](https://docs.google.com/forms/d/e/1FAIpQLSdKm6oLYRXlZOhEZMVmjoIn4eBToVYNmF6fwpm5GAIipQmPxA/viewform?pli=1)
+* Participate in end-user discussions asynchronously on Slack or synchronously via Google Meet.
+* Follow this page and [#opentelemetry](https://cloud-native.slack.com/archives/CJFCJHG4Q) to learn about new engagement opportunities as we grow our efforts.
+* Encourage other end-users to join and get involved!
+
+
+As someone interested in user research and/or improving the user experience of OpenTelemetry, you may want to:
+
+* Attend the [SIG meetings](https://docs.google.com/document/d/1e-UNZA3Tuno9b53RQbe--whUcO0VIXF3P81oXsrBK6g) and contribute to our efforts.
+* Become an end-user interview facilitator or helper.
+* Follow our work coordination efforts in [#otel-sig-end-user](https://cloud-native.slack.com/archives/C01RT3MSWGZ).
+* Amplify the existence of our surveys and end-user engagement opportunities to interested people!
+
+## Communication
+We coordinate our SIG efforts in [#otel-sig-end-user](https://cloud-native.slack.com/archives/C01RT3MSWGZ) on CNCF Slack.
+
+If you are new, you can create a CNCF Slack account [here](https://slack.cncf.io/).

--- a/end-user-interviews/README.md
+++ b/end-user-interviews/README.md
@@ -1,0 +1,35 @@
+# <img src="https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png" alt="OpenTelemetry Icon" width="45" height=""> OpenTelemetry community End User interview FAQ
+
+## What are end user interviews? 
+
+- The OpenTelemetry community conducts end user interviews to gather high fidelity information from users though the medium of synchronous discussions to learn about their challenges, preferences, and behaviors regarding OpenTelemetry. 
+
+## Why do these interviews happen? 
+
+- Many vendors in this space conduct interviews with their customers but that feedback doesn't always make its way back to the community directly. These interviews will help us test our assumptions, categorize end-users, and describe their needs so that the community can react to their feedback. 
+
+## When do these sessions happen? 
+- Our end user working group goal is to hold at least one session a month. 
+- Our scheduling preference is for these sessions to occur at 10:00 AM PST on Thursdays, however the final schedule will be dictated by the end-user interviewee’s availability.
+
+## Are the interview sessions recorded? 
+- Sessions are only recorded if the end user is comfortable with them being recorded. In this directory, you can find links to both video recordings and session summaries created by the Facilitator and Helper roles, as appropriate. 
+
+## What are the end user interview roles?
+
+* ### Interview Facilitator: - Required
+  -  The interview facilitator is a named role for each session and is responsible for the end-to-end control of the interview.  The facilitator identifies end-users, confirms their availability and schedules the interview. The facilitator can ask questions themselves and lead the interview, or they can delegate the flow of the discussion to another named person. If there is a known agenda/area of feedback the facilitator communicates this to the end-user to prepare them for a successful session. The facilitator follows up post-interview with a note of appreciation for the end-users participation. 
+
+* ### End-user Interviewee: - Required
+  - The end-user interviewee communicates their preference on scheduling and session duration. The end-user attends and shares feedback and stories about their experience with OpenTelemetry. 
+  - Interviewee selection criteria vary and change depending on the needs of the community. Some example criteria includes “people who have used OTel before”, “people who have implemented monitoring, telemetry, observability either in code or in platforms”, “people who develop software and don’t feel they have enough information about how it works in environments other than their laptop”
+
+* ### OTel Community Helper: - Required
+  - The OTel community helper is a named role for each session. The community helper will complete coordination and amplification tasks such as tracking session recording links, acting as note keeper, and publishing up an interview summary. The community helper can also be the same person as the interview facilitator. 
+
+* ### OTel Community member audience: - Optional
+  - Members from the OTel community are welcome to observe the interview and coordinate with the facilitator if there are any specific topics they’d like to be included during the interview. 
+
+## How can I get involved or learn more?
+- Are you interested in providing the community your feedback in this way? Please contact us in [#otel-user-research](https://cloud-native.slack.com/archives/C01RT3MSWGZ) on CNCF Slack to talk about scheduling. And as always, you can provide your feedback to the community in many ways including our community surveys too. 
+- Are you someone who is passionate about gathering and sharing end user feedback? Would you like to help us conduct interviews, improve how we solicit feedback or design a more robust end user interview program? If so, we'd love to hear from you too! We are a friendly, collaborative group and look forward to working together!

--- a/end-user-interviews/end-user-interview-outcomes/README.md
+++ b/end-user-interviews/end-user-interview-outcomes/README.md
@@ -1,0 +1,14 @@
+# <img src="https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png" alt="OpenTelemetry Icon" width="45" height=""> OpenTelemetry Historical end user interview resources
+
+This serves to transparently organize our interview activities and findings
+
+### August 2022: n/a
+- Summer break!
+
+### July 2022: Shopify
+- Recording Link: https://www.youtube.com/watch?v=AZJT4LHdygU
+- Summary: [not currently available]
+
+### June 2022: Anonymous technology development platform company
+- Recording link: n/a
+- [Summary](june-2022-techdevplatform.md)

--- a/end-user-interviews/end-user-interview-outcomes/june-2022-techdevplatform.md
+++ b/end-user-interviews/end-user-interview-outcomes/june-2022-techdevplatform.md
@@ -1,0 +1,52 @@
+# <img src="https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png" alt="OpenTelemetry Icon" width="45" height=""> June 2022 End User Interview
+## Who: 
+- An engineer on a technology development platform centralized observability team *and* OpenTelemetry project SDK maintainer.
+
+## Stack/What they’re trying to Observe: 
+- C
+- C#
+- C++
+- Go
+- Java
+- JavaScript (TypeScript, Node.JS)
+- .NET Core
+- Python
+- Ruby
+- Rust
+
+They also want to observe Kafka (subscriber model)
+
+The company heavily uses logs and Statsd.
+
+They want to instrument their Hosted SaaS & On Prem offerings.
+
+
+## Their end vision for OTel:
+They are focused for the moment in Tracing. They want to report traces that increase the efficiency of production tasks. 
+Instrumentation goals deal with operational matters, does not include business intelligence use cases.
+
+## Why OTel:
+Create a better experience for engineers, support staff and customers.
+Want to enable their customers to have a “bring your own telemetry offering.” The company wants to rely on OTel to give the choice to their own customers on where they want to export the telemetry from their platform. 
+
+## Challenges:
+1. Getting engineers on other teams bootstrapped to use OpenTelemetry
+  - Their team has created some install guides and opinionated setups, but this takes time and is not complete. 
+     - The ergonomics for adding span attributes are a challenge in some languages and not generally consistent
+     - Specific Ask: There are reasonable configuration defaults, but not every language does it the same way. 
+    - The centralized observability team commonly reviews PRs from other teams so they can provide feedback before merge which help enforce rules and control costs
+- Documentation is confusing and overwhelming
+  - Specific Ask: Create a consistent voice in the documentation. 
+  - The company contributes upstream to project documentation
+2. Maturity of auto-instrumentation
+  - Things don’t work ‘magically’ for other team developers; this is a different experience than most developers have had with commercial solutions.  
+3. Maturity of semantic conventions is hindering enthusiasm and wide internal adoption
+They’re defining internal semantic conventions 
+
+## Positive notes:
+A recent expansion which includes node.js and rust components has recently gone to production and:  “so far so great”
+
+## Notes of Interest: 
+- Their usage of the collector is minimal, running a PoC now.  They would like to get recommendations on the right sizing for the collector. Requires managing the authentication layer with their proxy to make it work.  
+- They have an internal distribution of Ruby OTel.
+- Their company is very logs focused; tracing is not widely adopted. A logs focus has affected how they adopt the project considering the emerging maturity of logs. 

--- a/end-user-interviews/end-user-interview-process.md
+++ b/end-user-interviews/end-user-interview-process.md
@@ -1,0 +1,41 @@
+# <img src="https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png" alt="OpenTelemetry Icon" width="45" height=""> OpenTelemetry community Interview Discussion Guide
+ 
+ This template outlines a best practice flow for for end user interviews. This guidance might be especially helpful if there is no pre-defined session agenda.
+ 
+Suggested Interview Flow (30/60 minute duration)
+
+## Housekeeping (~5 min)
+- [ ] Welcome the end user and thank them for participating.
+- [ ] Confirm it’s ok to record the interview. [Start Recording if not auto-enabled]
+- [ ] Outline the expected flow for the interview, highlighting any special topics and that there will be time for the audience and the end-user to ask questions too.
+- [ ] Introduce yourself and ask them to introduce themselves (and the audience too if time allows)
+ 
+## Warm-up questions (~3 / 10 min)
+This section helps set the stage for the session and provides context that should allow for more insightful questions to be asked later.
+- Please tell us about your role in the company.
+- What are the top 3 problems that you’re now facing in your role?
+- Can you describe your architecture, programming languages that your organization uses, and deployment environment? How do you deploy applications today?
+- How are the apps/services that you work with currently instrumented and/or logged?
+- What telemetry are you capturing, and where are you sending it?
+- How do you interact with telemetry coming from apps/services in your org? If not, who?
+- Are you using vendor-specific telemetry instrumentation? If so, why?
+
+## Meaty questions (~15 / 25 min) 
+This section will depend upon goals for the interview and what assumptions and/or hypothesis is being tested, some suggested questions are below:
+- What [would] prevents you from implementing [better] telemetry?
+- Who else is also involved in improving your telemetry landscape?
+- Are you interested in contributing to this project/community, if so what challenges do you have with that?
+
+## [Optional] Observer questions (~0 / 5 min)
+- Ask the audience if they have any questions for the end user
+
+## Turn the tables (~5 / 10 min)
+- [ ] Ask the end user what questions, if any, you or the folks on the call can answer for them 
+
+## Wrap it up (~3 min)
+- [ ] Thank the end user for their time 
+ 
+   
+
+---- 
+This guidance was heavily inspired by and adapted from Atlassian's Customer Interview Teams Playbook found here: https://www.atlassian.com/team-playbook/plays/customer-interview

--- a/end-user-surveys/README.md
+++ b/end-user-surveys/README.md
@@ -1,0 +1,66 @@
+# <img src="https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png" alt="OpenTelemetry Icon" width="45" height=""> OpenTelemetry community surveys
+This document is intended to outline best practices for long running and durable OpenTelemetry community surveys. 
+
+The OpenTelemetry community would like to gather data about end-users including their experiences, preferences, perceptions and opinions about OpenTelemetry. This data can be used to inform priorities within various OpenTelemetry projects. 
+
+# Active Surveys: 
+1: [OpenTelemetry Quarterly Feedback Survey](https://docs.google.com/forms/d/e/1FAIpQLSdKm6oLYRXlZOhEZMVmjoIn4eBToVYNmF6fwpm5GAIipQmPxA/viewform?pli=1)
+   
+- Intent: Gather quantitative data on our end-user community through a simple periodic survey that provides insight with established long running Key Results that we can trend over time. Recruit end-users for future qualitative studies and surveys
+- Survey owners: @sharrmander and @henrikrexed
+- Duration: This survey will be available in perpetuity with some intentional advertising/pushing once a quarter to submit feedback. 
+- Distribution: Survey Results will be summarized on a quarterly basis 
+- [Anonymized raw quarterly feedback survey results](https://docs.google.com/spreadsheets/d/1j2jFe9LLuhJS-NX2xy78ugMo5gDeG-zZeQLOTsgUDTw/edit#gid=0)
+
+# Community survey best practices
+
+### Community survey principles
+- User feedback should be a mix of qualitative and quantitative:
+  - Qualitative to validate/invalidate hypotheses
+  - Quantitative to set a baseline for key results and segment customers
+- All user feedback will be collected anonymously except direct customer interviews
+- Raw data should be transparent to the community/world
+- The end user working group will reach consensus on key milestones, including:
+  - Recurring/perpetual survey design
+  - Survey Hypotheses
+  - Measuring Key Results
+  - Survey Best Practices
+  - Summarizing and reporting results
+
+### Recognized Survey Types: 
+1. Direct Survey (anonymous)
+    - OpenTelemetry end user submits survey form
+
+2. Vendor-mediated Customer Interview (semi-anonymous)
+    - Vendor interviews customer & then submits survey form on end-user’s behalf
+
+### Survey reminders: 
+- Be respectful of the survey-takers' time, in general try to keep the survey short in duration, with specific and targeted questions. You can always ask if you can follow up with them to get deeper context.
+- We want to measure improvements too, so using trendable questions helps us assess how we’re doing 
+- We encourage mix of general and targeted surveys
+
+### Helpful questions and considerations: 
+
+- Audience identification: 
+   - Who will participate in the survey? What is their user role?
+  - Do you need any segmentation or demographic information to meet your survey goals?
+  - How many participants do you need for success? 
+- Establish Survey Intent & Goals:
+  - What are you looking to learn/identify/measure?
+  - How will the data be used?
+  - What are the survey Key Results?
+- Crafting Survey Questions: 
+  - What is the problem/feedback you want to gather data on?
+  - Should you be looking for quantitative or qualitative information, or both?
+- Distribution Channels: 
+  - Where will the survey be advertised?
+  - How will end-users be invited to participate? 
+- How do you plan to analyze & distribute the survey responses: 
+  - How will the data be reported? 
+  - What can be summarized? 
+  - Do you have any conclusions, insights or recommendations?
+
+Survey best practices resources were heavily inspired by these resources: 
+
+- [Survey Research Step-by-step Guide](https://www.scribbr.com/methodology/survey-research/)
+- [Types of Survey Questions](https://www.smartsurvey.co.uk/survey-questions/types)


### PR DESCRIPTION
This PR:

* Copies content from https://github.com/open-telemetry/community/tree/main/working-groups/end-user
* Removes mentions of "working group" in favour of SIG and updates links
* Removes content related to end-user discussion groups.