### PR TITLE
Add issue templates for OTel in Practice and Q&A

### DIFF
--- a/.github /ISSUE_TEMPLATE/otel_in_practice.md
+++ b/.github /ISSUE_TEMPLATE/otel_in_practice.md
@@ -24,7 +24,7 @@ The following list contains sub-tasks that need to be completed as part of organ
 - [ ] Create promo image for socials
 - [ ] Create OpenTelemetry public calendar event (including Zoom link)
 - [ ] Create CNCF event
-- [ ] Promote on OpenTelemetry socials (LinkedIn, X, Bluesky, Mastodon)
+- [ ] Promote on OpenTelemetry socials (LinkedIn, X, Bluesky, Mastodon) - make sure that these point to the CNCF event link
 - [ ] Promote on CNCF Slack channels ([#otel-announcements](https://cloud-native.slack.com/archives/C049G9W5NQ7), [#otel-sig-end-users](https://cloud-native.slack.com/archives/C01RT3MSWGZ), [#o11y-ambassadors](https://cloud-native.slack.com/archives/C050WLWHV1U))
 - [ ] Host session
 - [ ] Edit recording

--- a/.github /ISSUE_TEMPLATE/otel_in_practice.md
+++ b/.github /ISSUE_TEMPLATE/otel_in_practice.md
@@ -13,8 +13,8 @@ assignees: ''
 
 TBD
 
-### Description used for events
-<!-- Add here a description that will be used in events generated for the event -->
+### Description used for promotional posts and event descriptions
+<!-- Add here the main description that will be used in promotional posts and event invites -->
 
 ### Tasks
 The following list contains sub-tasks that need to be completed as part of organising, recording, and publicising the episode. Please replace items with individual links to issues where appropriate.

--- a/.github /ISSUE_TEMPLATE/otel_in_practice.md
+++ b/.github /ISSUE_TEMPLATE/otel_in_practice.md
@@ -28,4 +28,4 @@ The following list contains sub-tasks that need to be completed as part of organ
 - [ ] Promote on CNCF Slack channels ([#otel-announcements](https://cloud-native.slack.com/archives/C049G9W5NQ7), [#otel-sig-end-users](https://cloud-native.slack.com/archives/C01RT3MSWGZ), [#o11y-ambassadors](https://cloud-native.slack.com/archives/C050WLWHV1U)) - make sure that these point to the CNCF event link
 - [ ] Host session
 - [ ] Edit recording
-- [ ] Publish recording
+- [ ] Publish recording & promote on socials

--- a/.github /ISSUE_TEMPLATE/otel_in_practice.md
+++ b/.github /ISSUE_TEMPLATE/otel_in_practice.md
@@ -25,7 +25,7 @@ The following list contains sub-tasks that need to be completed as part of organ
 - [ ] Create OpenTelemetry public calendar event (including Zoom link)
 - [ ] Create CNCF event
 - [ ] Promote on OpenTelemetry socials (LinkedIn, X, Bluesky, Mastodon) - make sure that these point to the CNCF event link
-- [ ] Promote on CNCF Slack channels ([#otel-announcements](https://cloud-native.slack.com/archives/C049G9W5NQ7), [#otel-sig-end-users](https://cloud-native.slack.com/archives/C01RT3MSWGZ), [#o11y-ambassadors](https://cloud-native.slack.com/archives/C050WLWHV1U))
+- [ ] Promote on CNCF Slack channels ([#otel-announcements](https://cloud-native.slack.com/archives/C049G9W5NQ7), [#otel-sig-end-users](https://cloud-native.slack.com/archives/C01RT3MSWGZ), [#o11y-ambassadors](https://cloud-native.slack.com/archives/C050WLWHV1U)) - make sure that these point to the CNCF event link
 - [ ] Host session
 - [ ] Edit recording
 - [ ] Publish recording

--- a/.github /ISSUE_TEMPLATE/otel_in_practice.md
+++ b/.github /ISSUE_TEMPLATE/otel_in_practice.md
@@ -27,4 +27,5 @@ The following list contains sub-tasks that need to be completed as part of organ
 - [ ] Promote on OpenTelemetry socials (LinkedIn, X, Bluesky, Mastodon)
 - [ ] Promote on CNCF Slack channels ([#otel-announcements](https://cloud-native.slack.com/archives/C049G9W5NQ7), [#otel-sig-end-users](https://cloud-native.slack.com/archives/C01RT3MSWGZ), [#o11y-ambassadors](https://cloud-native.slack.com/archives/C050WLWHV1U))
 - [ ] Host session
-- [ ] Edit and publish recording
+- [ ] Edit recording
+- [ ] Publish recording

--- a/.github /ISSUE_TEMPLATE/otel_in_practice.md
+++ b/.github /ISSUE_TEMPLATE/otel_in_practice.md
@@ -1,0 +1,30 @@
+---
+name: OTel in Practice
+about: Issue tracking a new episode of OTel in Practice
+title: 'OTel in Practice: <name>'
+labels: OTel in Practice
+assignees: ''
+
+---
+<!-- Please remember to change the title of this issue by replacing <name> with the actual name for the session. This will be the title used in event invites -->
+
+### Date and time for the session
+<!-- Add here the proposed date for the event after it's been agreed -->
+
+TBD
+
+### Description used for events
+<!-- Add here a description that will be used in events generated for the event -->
+
+### Tasks
+The following list contains sub-tasks that need to be completed as part of organising, recording, and publicising the episode. Please replace items with individual links to issues where appropriate.
+
+- [ ] Confirm speakers
+- [ ] Confirm date and time
+- [ ] Create promo image for socials
+- [ ] Create OpenTelemetry public calendar event (including Zoom link)
+- [ ] Create CNCF event
+- [ ] Promote on OpenTelemetry socials (LinkedIn, X, Bluesky, Mastodon)
+- [ ] Promote on CNCF Slack channels ([#otel-announcements](https://cloud-native.slack.com/archives/C049G9W5NQ7), [#otel-sig-end-users](https://cloud-native.slack.com/archives/C01RT3MSWGZ), [#o11y-ambassadors](https://cloud-native.slack.com/archives/C050WLWHV1U))
+- [ ] Host session
+- [ ] Edit and publish recording

--- a/.github /ISSUE_TEMPLATE/otel_q_and_a.md
+++ b/.github /ISSUE_TEMPLATE/otel_q_and_a.md
@@ -13,15 +13,16 @@ assignees: ''
 
 TBD
 
-### Description used for events
-<!-- Add here a description that will be used in events generated for the event -->
+### Description used for promotional posts and event descriptions
+<!-- Add here the main description that will be used in promotional posts and event invites -->
 
 ### Tasks
 The following list contains sub-tasks that need to be completed as part of organising, recording, and publicising the episode. Please replace items with individual links to issues where appropriate.
 
 - [ ] Confirm speakers
 - [ ] Confirm date and time
-- [ ] Create Q&A doc
+- [ ] Make a copy of the [Q&A interview template](https://docs.google.com/document/d/1vi6NpSj3MvKTuNwFpE8toywHP0sWiH4bsE3AOWvgSwo/edit)
+- [ ] Fill in the template fields highlighted in blue
 - [ ] Create promo image for socials
 - [ ] Create OpenTelemetry public calendar event (including Zoom link)
 - [ ] Create CNCF event

--- a/.github /ISSUE_TEMPLATE/otel_q_and_a.md
+++ b/.github /ISSUE_TEMPLATE/otel_q_and_a.md
@@ -26,6 +26,7 @@ The following list contains sub-tasks that need to be completed as part of organ
 - [ ] Create OpenTelemetry public calendar event (including Zoom link)
 - [ ] Create CNCF event
 - [ ] Promote on OpenTelemetry socials (LinkedIn, X, Bluesky, Mastodon) - make sure that these point to the CNCF event link
-- [ ] Promote on CNCF Slack channels ([#otel-announcements](https://cloud-native.slack.com/archives/C049G9W5NQ7), [#otel-sig-end-users](https://cloud-native.slack.com/archives/C01RT3MSWGZ), [#o11y-ambassadors](https://cloud-native.slack.com/archives/C050WLWHV1U))
+- [ ] Promote on CNCF Slack channels ([#otel-announcements](https://cloud-native.slack.com/archives/C049G9W5NQ7), [#otel-sig-end-users](https://cloud-native.slack.com/archives/C01RT3MSWGZ), [#o11y-ambassadors](https://cloud-native.slack.com/archives/C050WLWHV1U)) - make sure that these point to the CNCF event link
 - [ ] Host session
-- [ ] Edit and publish recording
+- [ ] Edit recording
+- [ ] Publish recording

--- a/.github /ISSUE_TEMPLATE/otel_q_and_a.md
+++ b/.github /ISSUE_TEMPLATE/otel_q_and_a.md
@@ -30,4 +30,4 @@ The following list contains sub-tasks that need to be completed as part of organ
 - [ ] Promote on CNCF Slack channels ([#otel-announcements](https://cloud-native.slack.com/archives/C049G9W5NQ7), [#otel-sig-end-users](https://cloud-native.slack.com/archives/C01RT3MSWGZ), [#o11y-ambassadors](https://cloud-native.slack.com/archives/C050WLWHV1U)) - make sure that these point to the CNCF event link
 - [ ] Host session
 - [ ] Edit recording
-- [ ] Publish recording
+- [ ] Publish recording & promote on socials

--- a/.github /ISSUE_TEMPLATE/otel_q_and_a.md
+++ b/.github /ISSUE_TEMPLATE/otel_q_and_a.md
@@ -1,0 +1,31 @@
+---
+name: OTel Q&A
+about: Issue tracking a new episode of OTel Q&A
+title: 'OTel Q&A: <name>'
+labels: OTel Q&A
+assignees: ''
+
+---
+<!-- Please remember to change the title of this issue by replacing <name> with the actual name for the session. This will be the title used in event invites -->
+
+### Date and time for the session
+<!-- Add here the proposed date for the event after it's been agreed -->
+
+TBD
+
+### Description used for events
+<!-- Add here a description that will be used in events generated for the event -->
+
+### Tasks
+The following list contains sub-tasks that need to be completed as part of organising, recording, and publicising the episode. Please replace items with individual links to issues where appropriate.
+
+- [ ] Confirm speakers
+- [ ] Confirm date and time
+- [ ] Create Q&A doc
+- [ ] Create promo image for socials
+- [ ] Create OpenTelemetry public calendar event (including Zoom link)
+- [ ] Create CNCF event
+- [ ] Promote on OpenTelemetry socials (LinkedIn, X, Bluesky, Mastodon)
+- [ ] Promote on CNCF Slack channels ([#otel-announcements](https://cloud-native.slack.com/archives/C049G9W5NQ7), [#otel-sig-end-users](https://cloud-native.slack.com/archives/C01RT3MSWGZ), [#o11y-ambassadors](https://cloud-native.slack.com/archives/C050WLWHV1U))
+- [ ] Host session
+- [ ] Edit and publish recording

--- a/.github /ISSUE_TEMPLATE/otel_q_and_a.md
+++ b/.github /ISSUE_TEMPLATE/otel_q_and_a.md
@@ -25,7 +25,7 @@ The following list contains sub-tasks that need to be completed as part of organ
 - [ ] Create promo image for socials
 - [ ] Create OpenTelemetry public calendar event (including Zoom link)
 - [ ] Create CNCF event
-- [ ] Promote on OpenTelemetry socials (LinkedIn, X, Bluesky, Mastodon)
+- [ ] Promote on OpenTelemetry socials (LinkedIn, X, Bluesky, Mastodon) - make sure that these point to the CNCF event link
 - [ ] Promote on CNCF Slack channels ([#otel-announcements](https://cloud-native.slack.com/archives/C049G9W5NQ7), [#otel-sig-end-users](https://cloud-native.slack.com/archives/C01RT3MSWGZ), [#o11y-ambassadors](https://cloud-native.slack.com/archives/C050WLWHV1U))
 - [ ] Host session
 - [ ] Edit and publish recording


### PR DESCRIPTION
Adds issue templates for OTel in Practice and OTel Q&A. This can be iterated over later as we follow these templates and find things that may be missing (or docs that may be missing)