### PR TITLE
Add info about SIG maintainers & approvers to the main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,5 @@ If you are new, you can create a CNCF Slack account [here](https://slack.cncf.io
 * [@danielgblanco](https://github.com/danielgblanco)
 * [@reese-lee](https://github.com/reese-lee)
 
-#### Approvers
-* [@AnaMMedina21](https://github.com/AnaMMedina21)
-* [@IAMebonyhope](https://github.com/IAMebonyhope)
+#### Triagers
+* [@AndrejKiri](https://github.com/AndrejKiri)

--- a/README.md
+++ b/README.md
@@ -33,3 +33,14 @@ As someone interested in user research and/or improving the user experience of O
 We coordinate our SIG efforts in [#otel-sig-end-user](https://cloud-native.slack.com/archives/C01RT3MSWGZ) on CNCF Slack.
 
 If you are new, you can create a CNCF Slack account [here](https://slack.cncf.io/).
+
+## SIG End-user Leadership
+
+#### Maintainers
+* [@avillela](https://github.com/avillela)
+* [@danielgblanco](https://github.com/danielgblanco)
+* [@avillela](https://github.com/avillela)
+
+#### Approvers
+* [@AnaMMedina21](https://github.com/AnaMMedina21)
+* [@IAMebonyhope](https://github.com/IAMebonyhope)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ We coordinate our SIG efforts in [#otel-sig-end-user](https://cloud-native.slack
 
 If you are new, you can create a CNCF Slack account [here](https://slack.cncf.io/).
 
-## SIG End-user Leadership
+## Project Leadership
 
 #### Maintainers
 * [@avillela](https://github.com/avillela)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you are new, you can create a CNCF Slack account [here](https://slack.cncf.io
 #### Maintainers
 * [@avillela](https://github.com/avillela)
 * [@danielgblanco](https://github.com/danielgblanco)
-* [@avillela](https://github.com/avillela)
+* [@reese-lee](https://github.com/reese-lee)
 
 #### Approvers
 * [@AnaMMedina21](https://github.com/AnaMMedina21)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ We coordinate our SIG efforts in [#otel-sig-end-user](https://cloud-native.slack
 
 If you are new, you can create a CNCF Slack account [here](https://slack.cncf.io/).
 
-## Project Leadership
+## SIG Leadership
 
 #### Maintainers
 * [@avillela](https://github.com/avillela)


### PR DESCRIPTION
I propose to include contact info of the SIG leadership in the README, just as in https://github.com/open-telemetry/sig-security or https://github.com/open-telemetry/sig-mainframe. I think this will make it easier for new contributors to see who to contact about their contributions. 

For your review @avillela @danielgblanco @reese-lee @AnaMMedina21