### PR TITLE
Add issue reaction tip to every issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/otel_in_practice.md
+++ b/.github/ISSUE_TEMPLATE/otel_in_practice.md
@@ -29,3 +29,5 @@ The following list contains sub-tasks that need to be completed as part of organ
 - [ ] Host session
 - [ ] Edit recording
 - [ ] Publish recording & promote on socials
+
+<sub>**Tip**: React with 👍 to help prioritize this issue. Add more useful info in comments to help maintainers triage it. Learn more [here](https://opentelemetry.io/community/).</sub>

--- a/.github/ISSUE_TEMPLATE/otel_q_and_a.md
+++ b/.github/ISSUE_TEMPLATE/otel_q_and_a.md
@@ -31,3 +31,5 @@ The following list contains sub-tasks that need to be completed as part of organ
 - [ ] Host session
 - [ ] Edit recording
 - [ ] Publish recording & promote on socials
+
+<sub>**Tip**: React with 👍 to help prioritize this issue. Add more useful info in comments to help maintainers triage it. Learn more [here](https://opentelemetry.io/community/).</sub>

--- a/.github/ISSUE_TEMPLATE/survey.md
+++ b/.github/ISSUE_TEMPLATE/survey.md
@@ -23,4 +23,4 @@ assignees: ''
 - [ ] Write a blog post
 - [ ] Present findings at a maintainers meeting
 
-### Notes
+<sub>**Tip**: React with 👍 to help prioritize this issue. Add more useful info in comments to help maintainers triage it. Learn more [here](https://opentelemetry.io/community/).</sub>


### PR DESCRIPTION
As part of #11, this is an example of what issue templates can look like. This will later be linked from the maintainer guide as an example of how to add subheadings to issue templates.