### PR TITLE
Add a list of OTel Me Youtube links

### DIFF
--- a/end-user-interviews/end-user-interview-outcomes/README.md
+++ b/end-user-interviews/end-user-interview-outcomes/README.md
@@ -42,9 +42,6 @@ This serves to transparently organize our interview activities and findings.
 ### March 2023: Dough Ramirez from Uplight
 - Recording Link: https://www.youtube.com/watch?v=ptYWBF-R1Fc
 
-### August 2022: n/a
-- Summer break!
-
 ### July 2022: Shopify
 - Recording Link: https://www.youtube.com/watch?v=AZJT4LHdygU
 

--- a/end-user-interviews/end-user-interview-outcomes/README.md
+++ b/end-user-interviews/end-user-interview-outcomes/README.md
@@ -2,6 +2,46 @@
 
 This serves to transparently organize our interview activities and findings.
 
+
+### May 2025: Oluwatomisin Taiwo and Andrei Morozov from Compass Digital
+- Recording link: https://www.youtube.com/live/tTCuTAPE5aQ
+
+### April 2025: Eromosele Akhigbe
+- Recording link: https://www.youtube.com/watch?v=KzqY4roXhHs
+
+### March 2025: Jerome Johnson & Cal Loomis from Relativity
+- Recording link: https://www.youtube.com/watch?v=DrD35XxTDsY
+
+### December 2024: Ariel Valentin from GitHub
+- Recording link: https://www.youtube.com/watch?v=vB9_SiTV5CI
+
+### November 2024: Dan Ravenstone from Top Hat
+- Recording link: https://www.youtube.com/watch?v=BMkckCQN8eg
+
+### October 2024: Steven Swartz
+- Recording link: https://www.youtube.com/watch?v=3c9Bnldt128
+
+### June 2024: Daniel Dias and Oscar Reyes from Tracetest
+- Recording link: https://www.youtube.com/watch?v=KR8j11FECgc
+
+### December 2023: Luiz Aoqui of HashiCorp
+- Recording link: https://www.youtube.com/watch?v=HRIx9gJtECU
+
+### December 2023: Jennifer Moore
+- Recording link: https://www.youtube.com/watch?v=ztrknOWIUh8
+
+### September 2023: Hazel Weakly
+- Recoridng link: https://www.youtube.com/watch?v=wMJEgrUnX7M
+
+### July 2023: Jacob Aronoff from Lightstep
+- Recording link: https://www.youtube.com/watch?v=dpXhgZL9tzU
+
+### June 2023: Iris Dyrmishi from Farfetch
+- Recording link: https://www.youtube.com/watch?v=9iaGG-YZw5I
+
+### March 2023: Dough Ramirez from Uplight
+- Recording Link: https://www.youtube.com/watch?v=ptYWBF-R1Fc
+
 ### August 2022: n/a
 - Summer break!
 

--- a/end-user-interviews/end-user-interview-outcomes/README.md
+++ b/end-user-interviews/end-user-interview-outcomes/README.md
@@ -7,7 +7,6 @@ This serves to transparently organize our interview activities and findings.
 
 ### July 2022: Shopify
 - Recording Link: https://www.youtube.com/watch?v=AZJT4LHdygU
-- Summary: [not currently available]
 
 ### June 2022: Anonymous technology development platform company
 - Recording link: n/a

--- a/end-user-interviews/otel-me-discussion-guide.md
+++ b/end-user-interviews/otel-me-discussion-guide.md
@@ -1,4 +1,4 @@
-# <img src="https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png" alt="OpenTelemetry Icon" width="45" height=""> OpenTelemetry community Interview Discussion Guide
+# <img src="https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png" alt="OpenTelemetry Icon" width="45" height=""> OTel Me Discussion Guide
  
  This template outlines a best practice flow for for end user interviews. This guidance might be especially helpful if there is no pre-defined session agenda.
  


### PR DESCRIPTION
- Adding a list of the Youtube links to the OTel Me sessions to the README. The old list was outdated, I guess. 
- Update the title and file name of the discussion guide so it is not confusing

Related to https://github.com/open-telemetry/sig-end-user/issues/137