### PR TITLE
Use `pip-compile` package manager in Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,9 +5,16 @@
     'helpers:pinGitHubActionDigestsToSemver',
   ],
   pip_requirements: {
+    enabled: false
+  },
+  pip_setup: {
+    enabled: false
+  },
+  'pip-compile': {
+    enabled: true,
     managerFilePatterns: [
-      '/(^|/)video-transcripts/requirements\\.in$/',
-    ],
+      '/(^|/)video-transcripts/requirements\\.txt$/'
+    ]
   },
   packageRules: [
     {
@@ -27,6 +34,10 @@
       schedule: [
         'before 8am on Monday',
       ],
+    },
+    {
+      matchManagers: ['pip-compile'],
+      versioning: 'pep440'
     },
   ],
   labels: [


### PR DESCRIPTION
This PR changes the package manager to `pip-compile`, which will achieve the intended behaviour of bumping direct dependencies only if contained in `requirements.in`.

Changes:

1. Disables `pip_requirements` and `pip_setup` package managers (to avoid any potential future conflicts as documented [here](https://docs.renovatebot.com/modules/manager/pip-compile/#conflicts-with-other-managers)).
2. Enables `pip-compile` package manager (see need of `packageRules` as per discussion [here](https://github.com/renovatebot/renovate/discussions/39607)).