### PR TITLE
Limit Actions workflow to read-only permissions

### DIFF
--- a/.github/workflows/video-transcripts-tests.yml
+++ b/.github/workflows/video-transcripts-tests.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - 'video-transcripts/**'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds `contents: read` to the permissions to limit it to that scope.