### PR TITLE
fix markdown link to the Stripe survey blog

### DIFF
--- a/end-user-surveys/README.md
+++ b/end-user-surveys/README.md
@@ -44,7 +44,7 @@ Key info about the survey pipeline:
 14. Ensure questions options are mutually exclusive (e.g. 1-9, 10-99)
 15. Include 'Other' option if relevant
 
-For mode details check guidelines from [Stripe](ttps://stripe.com/en-cz/guides/atlas/survey-design-principles), [Survey Monkey](https://www.surveymonkey.com/learn/survey-best-practices/?), [Harvard Law School](https://hnmcp.law.harvard.edu/wp-content/uploads/2012/02/Arevik-Avedian-Survey-Design-PowerPoint.pdf), [Scribbr](https://www.scribbr.com/methodology/survey-research/), or [Smart Survey](https://www.smartsurvey.co.uk/survey-questions/types)
+For mode details check guidelines from [Stripe](https://stripe.com/en-cz/guides/atlas/survey-design-principles), [Survey Monkey](https://www.surveymonkey.com/learn/survey-best-practices/?), [Harvard Law School](https://hnmcp.law.harvard.edu/wp-content/uploads/2012/02/Arevik-Avedian-Survey-Design-PowerPoint.pdf), [Scribbr](https://www.scribbr.com/methodology/survey-research/), or [Smart Survey](https://www.smartsurvey.co.uk/survey-questions/types)
 
 ### Helpful questions and considerations: 
 


### PR DESCRIPTION
Adds the missing `h` character in the Stripe reference (`ttps` -> `https`), which previously rendered it without the intended hyperlink. 