### PR TITLE
Add Sophia as approver to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,4 @@ If you are new, you can create a CNCF Slack account [here](https://slack.cncf.io
 
 #### Approvers
 * [@nwanduka](https://github.com/nwanduka)
+* [@sophiesage](https://github.com/sophiesage)


### PR DESCRIPTION
I see that Sophia got her OTel membership (likely a while ago, but I didn't realize that) so I am adding her as an approver to our README. Once I get 👍 from maintainers, I will grant her approver role in GitHub.