### PR TITLE
Add general triage info and blueprints charter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,16 @@
 
 ## What is the End-User SIG?
 
-There are two primary goals of the End-User SIG:
-* Foster a sense of vendor-agnostic community for OpenTelemetry end-users to promote learning and adoption. We currently accomplish this through: [CNCF Slack channel](https://cloud-native.slack.com/archives/C01RT3MSWGZ), [panels](https://youtube.com/@otel-official) and blog posts.
+The primary goals of the End-User SIG are:
+* Fostering a sense of vendor-agnostic community for OpenTelemetry end-users to promote learning and adoption. We currently accomplish this through: [CNCF Slack channel](https://cloud-native.slack.com/archives/C01RT3MSWGZ), [panels](https://youtube.com/@otel-official) and blog posts.
 * Facilitate the collection and communication of end-user feedback to OpenTelemetry project special interest groups to influence SIG priorities. We currently accomplish this through: creation and maintenance of end-user research assets such as OpenTelemetry Community surveys & organization and facilitation of structured end-user interview sessions.
+* Produce vendor-neutral architectural guidance that helps end-users adopt and operate OpenTelemetry, in the form of [Blueprints and Reference Implementations](https://opentelemetry.io/docs/guidance/). See the [`architecture/`](./architecture) directory for templates and our contribution process.
 
 Our group discourages promotion of vendor-specific solutions and desires to keep the focus on OpenTelemetry core technologies, adoption and usage.
 
 ## Get Involved
 
-There are many ways to get involved in our work! We (End-User SIG) meet every two weeks on Thursdays at 10:00 PT/13:00 ET/19:00 CET. Check out the [OpenTelemetry Community calendar](https://github.com/open-telemetry/community?tab=readme-ov-file#calendar) for the Zoom link and any updates to this schedule.
+There are many ways to get involved in our work! We (End-User SIG) meet every week. Check out the [OpenTelemetry Community calendar](https://github.com/open-telemetry/community?tab=readme-ov-file#calendar) for the Zoom link and any updates to this schedule.
 
 Meeting notes are available as a [public Google doc](https://docs.google.com/document/d/1e-UNZA3Tuno9b53RQbe--whUcO0VIXF3P81oXsrBK6g). If you have trouble accessing the doc, please get in touch on [Slack](https://cloud-native.slack.com/archives/C01RT3MSWGZ).
 
@@ -19,6 +20,7 @@ As an end user, you may want to:
 * Reach out to us to tell us your OpenTelemetry adoption story. You can reach out in [#otel-sig-end-user](https://cloud-native.slack.com/archives/C01RT3MSWGZ) to learn more.
 * Take one of our surveys (for current surveys, check out the [OpenTelemetry website](https://opentelemetry.io/) or socials)
 * Participate in end-user discussions asynchronously on Slack or synchronously via Google Meet.
+* Open [Blueprint proposal](https://github.com/open-telemetry/sig-end-user/issues/new?template=blueprint_proposal.yml) or a [Reference Implementation proposal](https://github.com/open-telemetry/sig-end-user/issues/new?template=reference_implementation.yml).
 * Follow this page and [#opentelemetry](https://cloud-native.slack.com/archives/CJFCJHG4Q) to learn about new engagement opportunities as we grow our efforts.
 * Encourage other end-users to join and get involved!
 
@@ -33,6 +35,14 @@ As a contributor to other OTel SIGs that wants to run their own survey:
 * Create a new issue with the `Survey` template.
 * Review our [survey guidance](https://github.com/open-telemetry/sig-end-user/tree/main/end-user-surveys) and past surveys
 * Reach out in [#otel-sig-end-user](https://cloud-native.slack.com/archives/C01RT3MSWGZ) with any questions
+
+## Issue Triage
+
+Issues opened using one of our [issue templates](./.github/ISSUE_TEMPLATE) already come with a default label identifying the type of proposal, such as `end-user-survey`, `otel-me`, `otel-in-practice`, `whats-up-otel`, `blueprints` or `reference-implementations`.
+
+Blueprint and Reference Implementation issues follow a specific triage process and lifecycle beyond this initial labelling, documented in the [architecture README](./architecture/README.md#label-reference).
+
+Issues labelled `apac` are specifically worked on by APAC contributors, as they relate to events or surveys carried out in that region.
 
 ## Communication
 We coordinate our SIG efforts in [#otel-sig-end-user](https://cloud-native.slack.com/archives/C01RT3MSWGZ) on CNCF Slack.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 The primary goals of the End-User SIG are:
 * Fostering a sense of vendor-agnostic community for OpenTelemetry end-users to promote learning and adoption. We currently accomplish this through: [CNCF Slack channel](https://cloud-native.slack.com/archives/C01RT3MSWGZ), [panels](https://youtube.com/@otel-official) and blog posts.
-* Facilitate the collection and communication of end-user feedback to OpenTelemetry project special interest groups to influence SIG priorities. We currently accomplish this through: creation and maintenance of end-user research assets such as OpenTelemetry Community surveys & organization and facilitation of structured end-user interview sessions.
-* Produce vendor-neutral architectural guidance that helps end-users adopt and operate OpenTelemetry, in the form of [Blueprints and Reference Implementations](https://opentelemetry.io/docs/guidance/). See the [`architecture/`](./architecture) directory for templates and our contribution process.
+* Facilitating the collection and communication of end-user feedback to OpenTelemetry project special interest groups to influence SIG priorities. We currently accomplish this through: creation and maintenance of end-user research assets such as OpenTelemetry Community surveys & organization and facilitation of structured end-user interview sessions.
+* Producing vendor-neutral architectural guidance that helps end-users adopt and operate OpenTelemetry, in the form of [Blueprints and Reference Implementations](https://opentelemetry.io/docs/guidance/). See the [`architecture/`](./architecture) directory for templates and our contribution process.
 
 Our group discourages promotion of vendor-specific solutions and desires to keep the focus on OpenTelemetry core technologies, adoption and usage.
 

--- a/sig-end-user-charter.md
+++ b/sig-end-user-charter.md
@@ -48,6 +48,17 @@ implementation, including:
 * Host panels with end users 
 * Host time-limited surveys 
 
+#### Blueprints and Reference Implementations
+
+Produce and maintain vendor-neutral [architectural guidance](https://opentelemetry.io/docs/guidance/) 
+that helps organizations adopt and operate OpenTelemetry, including:
+
+* Review and approve proposals for new Blueprints and Reference Implementations, 
+raised as issues in this repository.
+* Author, or help author, specific Blueprints.
+* Maintain [templates and contribution guidance](https://github.com/open-telemetry/sig-end-user/tree/main/architecture) .
+for authoring Blueprints and Reference Implementations
+
 ### Out of scope
 
 SIG End User’s scope does not include:


### PR DESCRIPTION
Updates `README.md` and `sig-end-user-charter.md` to reflect the SIG's work on OpenTelemetry Blueprints and Reference Implementations, and adds a new "Issue Triage" section to the README covering:

- Default labels applied by issue templates (`end-user-survey`, `otel-me`, `otel-in-practice`, `whats-up-otel`, `blueprints`, `reference-implementations`)
- The dedicated triage and lifecycle for Blueprint/Reference Implementation issues, documented in `architecture/README.md`
- `apac`-labelled issues being handled by APAC contributors for region-specific events and surveys
