### PR TITLE
Add blueprint and reference implementation guidance docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/blueprint_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/blueprint_proposal.yml
@@ -11,7 +11,7 @@ body:
 
         A good blueprint starts with a clearly defined scope: **who** it is for and **what challenges** it will help them solve. Please be as specific as possible. This scope determines what content belongs in the blueprint and helps reviewers approve the creation of the document.
 
-        If you are willing to contribute to authoring the blueprint, please mention it below. The template to follow can be found at [`/architecture/blueprint-template.md`](https://github.com/open-telemetry/sig-end-user/blob/main/architecture/blueprint-template.md).
+        If you are willing to contribute to authoring the blueprint, please mention it below. The template to follow can be found at [`/architecture/blueprint-template.md`](https://github.com/open-telemetry/sig-end-user/blob/main/architecture/blueprint-template.md), and its authoring guidelines at [`/architecture/blueprint-guidelines.md`](https://github.com/open-telemetry/sig-end-user/blob/main/architecture/blueprint-guidelines.md).
         
         Please visit [our website](https://opentelemetry.io/docs/guidance/blueprints/) if you want to find out more about blueprints.
   - type: input

--- a/.github/ISSUE_TEMPLATE/reference_implementation.yml
+++ b/.github/ISSUE_TEMPLATE/reference_implementation.yml
@@ -13,7 +13,7 @@ body:
         
         Please visit [our website](https://opentelemetry.io/docs/guidance/reference-implementations/) if you want to find out more about reference implementations.
 
-        > **Note:** You do not need to have a full document ready to share when creating this issue. We can work with you to complete the template at [`/architecture/reference-implementation-template.md`](https://github.com/open-telemetry/sig-end-user/blob/main/architecture/reference-implementation-template.md) if required.
+        > **Note:** You do not need to have a full document ready to share when creating this issue. We can work with you to complete the template at [`/architecture/reference-implementation-template.md`](https://github.com/open-telemetry/sig-end-user/blob/main/architecture/reference-implementation-template.md) if required, following the authoring guidelines at [`/architecture/reference-implementation-guidelines.md`](https://github.com/open-telemetry/sig-end-user/blob/main/architecture/reference-implementation-guidelines.md).
   - type: input
     id: org_name
     attributes:

--- a/architecture/blueprint-guidelines.md
+++ b/architecture/blueprint-guidelines.md
@@ -1,0 +1,163 @@
+# Blueprint Authoring Guidelines
+
+This document contains the authoring guidance for [`blueprint-template.md`](./blueprint-template.md). Read it before
+you start filling in the template.
+
+## Overview
+
+A blueprint SHOULD be structured in a way that conveys a journey, from a current state to a desired state. The OTel
+Blueprint template is heavily influenced by the approach to strategic thinking popularized by Richard Rumelt in
+_Good Strategy/Bad Strategy_. Some optional reading if you want the background before writing a blueprint:
+
+- [Summary](https://itsadeliverything.com/good-strategy-bad-strategy-the-difference-and-why-it-matters-by-richard-rumelt)
+- [Interview](https://www.youtube.com/watch?v=4uWKEG0s9Kc)
+
+Some modifications must be applied to that framework, as OTel Blueprints are not scoped to solve a specific set of
+challenges for a single organization, but rather a common set of challenges as identified in end-user reference
+implementations, feedback surveys, and OpenTelemetry Live sessions.
+
+Effectively, an OTel Blueprint is structured in four core areas:
+
+- **Summary**: Introduces the target audience and environment, and the benefits from applying said blueprint. This
+  MUST be placed at the start of the document.
+- **Common Challenges**: The challenges to solve that, once solved, will generate the largest value for a particular
+  organization.
+- **General Guidelines**: The pattern that, if implemented, would solve the Common Challenges identified in the
+  previous block. Guidelines MUST NOT be included if they don't apply to at least one of the documented challenges.
+- **Implementation**: The list of actions to implement the General Guidelines, highlighting a plan that takes into
+  consideration interdependencies between these actions (i.e. coherently).
+
+Additionally, OTel Blueprints SHOULD optionally include these other sections:
+
+- **Background**: A brief introduction to the environment and the audience.
+- **Reference Implementations**: Links to reference implementations that implemented some, or all of the General
+  Guidelines. It is strongly encouraged to back blueprints with reference implementations that implement them. This
+  MUST be placed after the Implementation section.
+- **Appendix**: Any information that would make other sections too verbose. Include here sections like code
+  snippets, step-by-step operating guides, common issues and troubleshooting guidelines, etc. This MUST be placed at
+  the end of the document.
+
+The template uses an example, "Centralized Observability Platform on Kubernetes", to illustrate some of the defined
+blocks. Two types of punctuation are used to guide the author:
+
+- Text in `{curly brackets}` denotes details that MUST be filled in by the author, with examples inside the curly
+  brackets.
+- These guidelines exist so that authors don't need markdown comments embedded in the template itself to know what's
+  expected of each section.
+
+Authors MAY add more sections or reword any text within each of the sections, but MUST NOT remove any of the
+mandatory sections listed above.
+
+## Summary
+
+A brief, high-level overview of the intended audience, the applicable environment, and the outcomes achieved. It
+should answer the following questions:
+
+- Who is the intended audience for this blueprint? Identify the type of team or engineering role that will read this
+  blueprint and apply it.
+- What type of environment does this blueprint apply to? Identify the stack where these recommendations will be
+  applied.
+- What is the core goal and the outcomes that this blueprint will drive when applied? As one-liners, identify the
+  value that organizations get from applying this blueprint.
+
+## Background
+
+OPTIONAL. A brief introduction to the environment in scope, or the intended audience. This section is optional,
+however authors SHOULD consider adding it in order to keep the summary to a few paragraphs.
+
+## Common Challenges
+
+This section describes the inherent friction points of this specific environment/scenario, as backed by reference
+implementations, feedback surveys, and live sessions.
+
+- What typically breaks or slows down adoption?
+- How does this affect business or engineering practices?
+- What is normally a hard problem to solve and thus requires a coherent strategy?
+
+Authors MUST NOT focus on solutions, or goals, here. They SHOULD simply state the challenges that target audiences
+normally see in the environments in scope, as documented in existing reference implementations. In particular, they
+MUST avoid thinking about the need for a particular solution within these common challenges. For instance, they MUST
+NOT state something like "because of a lack of distributed tracing, we must provide a way to configure a
+TracerProvider". They SHOULD leave those statements for the Implementation section, so that actions can connect back
+to guiding policies.
+
+This section SHOULD focus on the root causes or the pivotal issues that, if resolved, deliver the most impact.
+Authors SHOULD NOT go into deep details, and they SHOULD NOT aim to cover every known problem in the environments in
+scope. Instead, they SHOULD highlight why particular challenges are important and the impact they have.
+
+This section MAY include diagrams that explain the high-level architecture or organizational structure where this
+blueprint applies. Authors SHOULD use Mermaid.js with default styles to create diagrams.
+
+A few additional practices help keep this section sharp:
+
+- **Don't list challenges for the sake of listing challenges.** Not all challenges are equal. Focus on the ones that
+  deliver the most value if solved, not on every improvement opportunity you noticed.
+- **Quantify impact.** You don't need exact numbers, but every challenge listed should have a tangible effect on
+  business or engineering outcomes (e.g. "the lack of automation in setting up instrumentation results in lower
+  engineering efficiency and developer productivity").
+- **Illustrate challenges, don't just describe them.** A diagram or a real screenshot of live account data makes a
+  challenge land faster than a paragraph of prose (e.g. a broken link between two systems that should share a standard).
+
+## General Guidelines
+
+This section contains a set of guidelines, or recommendations, that guide the general architectural philosophy to
+solve the common challenges. This is the North Star of the blueprint, so it MUST focus on the end-goal.
+
+- What does the resulting architecture look like after all actions are implemented?
+- How does it solve the documented challenges?
+- What additional benefits does it bring?
+- How can this optimize the way that teams operate or interact with each other?
+
+The author SHOULD define the boundaries for decision-making, both in terms of architecture (i.e. what part of the
+stack this applies to) and organization (i.e. what personas this affects and how they use OpenTelemetry tooling).
+
+Each guideline MUST address at least one challenge presented in the Common Challenges section. If a guideline does
+not directly help with any challenges, it MUST NOT be included. The author SHOULD ensure that recommendations explain
+the value of applying them — the "so that" behind the guideline. For example, a guideline should not simply state
+"Declarative config is provided to teams as a centralized config file", but rather "Declarative config is provided
+to teams as a centralized config file so that a consolidated set of domain-specific properties are applied with
+minimal friction, allowing configuration owners to quickly perform changes at scale".
+
+Diagrams SHOULD be used here to illustrate the North Star architecture or proposed interaction modes between teams.
+Authors SHOULD use Mermaid diagram definitions with default styles to facilitate maintenance.
+
+A few additional practices help keep guidelines actionable:
+
+- **Name what you're deliberately not recommending yet, and why.** A guiding policy is as much about what it rules
+  out as what it commits to. If a real alternative exists and it's premature to recommend it, say so explicitly and name
+  the constraint. Don't silently omit the alternative or try to recommend everything at once.
+
+## Implementation
+
+The specific technical implementation of the General Guidelines. This section aims to be more prescriptive, and list
+a series of actions that, if taken in a particular order, will help implement policies with maximum efficiency.
+
+List the concrete first steps (proximate objectives) that can be taken first, and those that can be done later,
+either by criticality or dependency between different tasks (e.g. in order to provide standard OTel pipelines, you
+first need to deploy a Collector gateway).
+
+Actions SHOULD reinforce each other (e.g. if the guideline is "standardization," an action to "let teams choose their
+own tools" would be incoherent). They MUST also link back to the guideline they help implement. If an action does
+not help implement a guideline, it MUST NOT be included.
+
+Actions SHOULD link to specific parts of the OpenTelemetry documentation, and they MUST NOT repeat aspects already
+documented elsewhere.
+
+A few additional practices help keep actions concrete:
+
+- **Avoid vague actions.** "Implement changes" isn't helpful — state the concrete deliverable expected once the action
+  is complete.
+
+## Reference Implementations
+
+Links to real-world adoption that validates this blueprint. This connects the theory to practice.
+
+## Appendix
+
+Each optional subsection here should represent an aspect that can reinforce the guidelines and actions presented
+above. It SHOULD NOT be a replacement for user documentation which can be found or contributed elsewhere in
+OpenTelemetry Docs. It SHOULD be focused on providing useful resources for readers and to extend guidance or actions
+presented above.
+
+Include here sections like code snippets, step-by-step operating guides, common issues and troubleshooting
+guidelines, etc.

--- a/architecture/blueprint-guidelines.md
+++ b/architecture/blueprint-guidelines.md
@@ -38,7 +38,7 @@ Additionally, OTel Blueprints SHOULD optionally include these other sections:
   the end of the document.
 
 The template uses an example, "Centralized Observability Platform on Kubernetes", to illustrate some of the defined
-blocks. Two types of punctuation are used to guide the author:
+blocks. The following conventions guide the author:
 
 - Text in `{curly brackets}` denotes details that MUST be filled in by the author, with examples inside the curly
   brackets.

--- a/architecture/blueprint-template.md
+++ b/architecture/blueprint-template.md
@@ -3,58 +3,9 @@ title: '{Blueprint Name, e.g., Centralized Observability Platform on Kubernetes}
 linkTitle: '{Blueprint Name, e.g., Centralized Observability Platform on Kubernetes}'
 ---
 
-<!--
-A blueprint SHOULD be structured in a way that conveys a journey, from a current state to a desired state.
-For this purpose, the OTel Blueprint template is based on the approach to strategic thinking popularized by Richard Rumelt in Good Strategy/Bad Strategy. See useful materials before starting to write a blueprint:
-
-- Summary - https://itsadeliverything.com/good-strategy-bad-strategy-the-difference-and-why-it-matters-by-richard-rumelt
-- Interview - https://www.youtube.com/watch?v=4uWKEG0s9Kc
-
-Some modifications must be applied to that framework, as OTel Blueprints are not scoped to solve a specific set of challenges for a single organization, but rather a common set of challenges as identified in end-user reference implementations, feedback surveys, and OpenTelemetry Live sessions.
-
-Effectively, an OTel Blueprint is structured in four core areas:
-
-- Summary: Introduces the target audience and environment, and the benefits from applying said blueprint.
-    This MUST be placed at the start of the document.
-- Common Challenges: The challenges to solve that, once solved, will generate the largest value for a particular organization.
-    This is referred to as the “Diagnosis” in Rumelt’s framework.
-- General Guidelines: The pattern that, if implemented, would solve the Common Challenges identified in the previous block.
-    Guidelines MUST NOT be included if they don’t apply to at least one of the documented challenges.
-    This is referred to as “Guiding Policy” in Rumelt’s framework.
-- Implementation: The list of actions to implement the General Guidelines, highlighting a plan that takes into consideration interdependencies between these actions (i.e. coherently).
-    This is referred to as “Coherent Actions” in Rumelt’s framework.
-
-Additionally, OTel Blueprints SHOULD optionally include these other sections:
-
-- Background: A brief introduction to the environment and the audience.
-- Reference Implementations: Links to reference implementations that implemented some, or all of the General Guidelines.
-    It is strongly encouraged to back blueprints with reference implementations that implement them.
-    This MUST be placed after the Coherent Actions section.
-- Appendix: Any information that would make other sections too verbose.
-    Include here sections like code snippets, step-by-step operating guides, common issues and troubleshooting guidelines, etc.
-    This MUST be placed at the end of the document.
-
-This template uses an example, i.e. "Centralized Observability Platform on Kubernetes" to illustrate some of the defined blocks.
-Two types of punctuation are used to guide the author:
-
-- Text in {curly brackets} denotes details that MUST be filled in by the author, with examples inside the curly brackets.
-- Text in <!- - markdown comments - -> denotes guidance that MUST not be included in the final document.
-
-Authors MAY add more sections or reword any text within each of the sections, but MUST not remove any of the mandatory sections listed above.
--->
+_Before filling in this template, read the [Blueprint authoring guidelines](./blueprint-guidelines.md)._
 
 ## Summary
-<!--
-A brief, high-level overview of the intended audience, the applicable environment, and the outcomes achieved.
-It should answer the following questions:
-
-- Who is the intended audience for this blueprint?
-    Identify the type of team or engineering role that will read this blueprint and apply it.
-- What type of environment does this blueprint apply to?
-    Identify the stack where these recommendations will be applied
-- What is the core goal and the outcomes that this blueprint will drive when applied?
-    As one-liners, identify the value that organizations get from applying this blueprint.
--->
 
 This blueprint outlines a strategic reference for {target audience, e.g., Platform Engineering teams} operating in {environment, e.g., large-scale, multi-tenant Kubernetes clusters}.
 
@@ -67,33 +18,10 @@ By implementing the patterns in this blueprint, organizations can expect to achi
  - {Other outcomes...}
 
 ## Background
-<!--
-OPTIONAL. A brief introduction to the environment in scope, or the intended audience.
-This section is optional, however authors SHOULD consider adding it in order to keep the summary to a few paragraphs.
--->
 
 {Background, e.g. Organizations are widely adopting a cloud native Platform Engineering team to reduce cognitive load and abstract complexity for the rest of their organization, and this also applies to observability...}
 
 ## Common Challenges
-<!--
-This section describes the inherent friction points of this specific environment/scenario, as backed by reference implementation, feedback surveys, and live sessions.
-
-- What typically breaks or slows down adoption?
-- How does this affect business or engineering practices?
-- What is normally a hard problem to solve and thus requires a coherent strategy?
-
-Authors MUST NOT focus on solutions, or goals, here.
-They SHOULD simply state the challenges that target audiences normally see in the environments in scope, as documented in existing reference implementations.
-In particular, they MUST avoid thinking about the need for a particular solution within these common challenges.
-For instance, they MUST NOT state something like “because of a lack of distributed tracing, we must provide a way to configure a TracerProvider”.
-They SHOULD leave those statements for the Coherent Actions section, so that actions can connect back to guiding policies.
-
-This section SHOULD focus on the root causes or the pivotal issues that, if resolved, deliver the most impact.
-Authors SHOULD NOT go into deep details, and they SHOULD NOT aim to cover every known problem in the environments in scope.
-Instead, they SHOULD highlight why particular challenges are important and the impact they have.
-
-This section MAY include diagrams that explain the high-level architecture or organizational structure where this blueprint is applied to. Authors SHOULD use Mermaid.js with default styles to create diagrams.
--->
 
 Organizations operating in this environment typically face a distinct set of challenges that hinder effective observability:
 
@@ -102,7 +30,6 @@ Organizations operating in this environment typically face a distinct set of cha
 {Description of the challenge, e.g., in multi-tenant Kubernetes clusters, distinct teams often adopt different instrumentation standards.}
 
 This leads to:
-<!-- Impact of the challenge -->
 - {Impact 1, e.g. Inconsistent Metadata: Telemetry lacks common resource attributes (e.g., `service.version`, `k8s.cluster.name`), breaking correlation across the stack.}
 - {Impact 2, e.g. High Cognitive Load: Developers must manually configure SDKs for every new service, increasing toil and the risk of misconfiguration.}
 - {Other impact...}
@@ -117,24 +44,6 @@ This leads to:
 
 
 ## General Guidelines
-<!--
-This section contains a set of guidelines, or recommendations, that guide the general architectural philosophy to solve the common challenges.
-This is the North Star of the blueprint, so it MUST focus on the end-goal.
-
-- What does the resulting architecture look like after all actions are implemented?
-- How does it solve the documented challenges?
-- What additional benefits does it bring?
-- How can this optimize the way that teams operate or interact with each other?
-
-The author SHOULD define the boundaries for decision-making, both in terms of architecture (i.e., what part of the stack this applies to) and organization (i.e., what personas this affects and how they use OpenTelemetry tooling). 
-
-Each guideline MUST address at least one challenge presented in the Common Challenges.
-If a guideline does not directly help with any challenges, it MUST NOT be included.
-The author SHOULD ensure that recommendations explain the value of applying them.
-For example, a guideline should not simply state "Declarative config is provided to teams as a centralized config file", but rather as "Declarative config is provided to teams as a centralized config file so that a consolidated set of domain-specific properties are applied with minimal friction, allowing configuration owners to quickly perform changes at scale".
-
-Diagrams SHOULD be used here to illustrate the North Star architecture or proposed interaction modes between teams. Authors SHOULD use Mermaid diagram definitions with default styles to facilitate maintenance.
--->
 
 ### 1. {Guideline 1: e.g., Decouple Instrumentation from Configuration}
 <small>Challenges Addressed: {Challenge Numbers, e.g., 1, 3}</small>
@@ -142,7 +51,6 @@ Diagrams SHOULD be used here to illustrate the North Star architecture or propos
 {Description of the guideline, e.g., we recommend shifting responsibility over default configurations from application developers to platform teams by using the OTel Operator, ensuring consistent SDK configuration.}
 
 By implementing this guideline, organizations can expect to achieve:
-<!-- Outcomes of the guideline -->
 - {Outcome 1, e.g. adoption of required Resource attributes becomes frictionless without developer intervention.}
 - {Outcome 1, e.g. context propagation works out of the box through service boundaries and asynchronous execution units.}
 - {Other outcomes...}
@@ -158,19 +66,6 @@ By implementing this guideline, organizations can expect to achieve:
 {Guideline description and expected outcomes as documented above}
 
 ## Implementation
-<!--
-The specific technical implementation of the General Guidelines.
-This section aims to be more prescriptive, and list a series of actions that, if taken in a particular order, will help implement policies with maximum efficiency.
-
-List the concrete first steps (proximate objectives) that can be taken first, and those that can be done later.
-Either by criticality or dependency between different tasks (e.g. in order to provide standard OTel pipelines, you first need to deploy a Collector gateway).
-
-Actions SHOULD reinforce each other (e.g., if the guideline is "standardization," an action to "let teams choose their own tools" would be incoherent).
-They MUST also link back to the guideline they help implement.
-If an action does not help implement a guideline, it MUST NOT be included.
-
-Actions SHOULD link to specific parts of the OpenTelemetry documentation, and they MUST NOT repeat aspects already documented elsewhere.
--->
 
 ### 1. {Action 1, e.g., Deploy a Collector Gateway}
 <small>Guidelines Supported: {Guideline Numbers, e.g. 2}</small>
@@ -189,22 +84,13 @@ Documentation:
 
 
 ## Reference Implementations
-<!--
-Links to real-world adoption that validates this blueprint. This connects the theory to practice.
--->
+
 The patterns described above have been successfully implemented by the following end-users:
 
 - {Link to Reference Implementation 1}
 - {Link to Reference Implementation 2}
 
 ## Appendix
-<!--
-Each optional subsection here will represent an aspect that can reinforce the guidelines and actions presented above.
-It SHOULD NOT be a replacement for user documentation which can be found or contributed elsewhere in OpenTelemetry Docs.
-It SHOULD be focused on providing useful resources for readers and to extend guidance or actions presented above.
-
-Include here sections like code snippets, step-by-step operating guides, common issues and troubleshooting guidelines, etc.
--->
 
 ### 1. {Appendix 1, e.g. Common Issues and Troubleshooting}
 

--- a/architecture/reference-implementation-guidelines.md
+++ b/architecture/reference-implementation-guidelines.md
@@ -1,0 +1,174 @@
+# Reference Implementation Authoring Guidelines
+
+This document contains the authoring guidance for
+[`reference-implementation-template.md`](./reference-implementation-template.md). Read it before you start filling
+in the template.
+
+## Overview
+
+This template is for documenting a reference implementation: a real-world account of how an organization has
+adopted OpenTelemetry in production.
+
+Unlike OTel Blueprints (which are challenge-oriented and prescriptive), reference implementations are evidence-based
+and narrative. Their purpose is to share how a specific organization approached OTel adoption, what choices they
+made, and what they learned.
+
+A good reference implementation tells a story. It explains:
+
+- Who the organization is and how it is structured.
+- What OpenTelemetry components they use and why.
+- How their architecture and configuration works in practice.
+- What worked, what didn't, and what they would do differently.
+
+This template contains sections which may not be applicable to the environment in scope, or even possible for the
+author to fill in. All sections are RECOMMENDED, helping the author drive the narrative, however the existence of
+any particular section is NOT REQUIRED.
+
+- Text in `{curly brackets}` denotes details that MUST be filled in by the author.
+
+Authors MAY remove sections if they're not applicable to their implementation, or if they cannot share information
+pertaining to that section for any reason. Authors MAY add additional sections, diagrams, or configuration examples.
+Authors SHOULD keep descriptions factual and evidence-based, avoiding generic claims. Authors MUST remove all
+`{curly bracket placeholders}` before publishing. Authors MAY include the names of the backend or vendor they used,
+but they MUST NOT include details related to why that backend was used, or the benefits/drawbacks of using it.
+
+## {Organization Name} Reference Implementation
+
+Introduce your organization in a paragraph or two. Explain what it does, who it serves, and any context that is
+relevant to understanding its observability challenges (e.g. open source product, decentralized architecture,
+non-profit, highly regulated industry). This section sets the scene.
+
+## Organizational structure
+
+Describe how your engineering organization is structured, with a focus on who is responsible for observability. Be
+specific: a single dedicated engineer looks very different from a single 20-person platform team, or a federated
+structure with multiple observability teams. All shapes and sizes are valid, and the contrast is useful for readers
+in similar situations.
+
+Include relevant information such as:
+
+- Total engineering headcount (approximate is fine)
+- Who owns observability tooling including SDK config, Collector Gateways, etc.
+- Whether ownership is centralized or distributed across teams
+- Who is responsible for instrumentation and ultimately data emissions
+- How observability teams interact with the rest of the organization
+
+## Environment and scale
+
+Describe the environment where OpenTelemetry is deployed: infrastructure, runtimes, deployment model, and scale.
+Include concrete numbers where possible. These help readers assess how closely their situation matches yours.
+
+Consider including:
+
+- Infrastructure: cloud provider(s), on-premise, hybrid
+- Orchestration: Kubernetes, VMs, serverless, etc.
+- Languages and runtimes instrumented
+- Number of services or applications
+- Request volume, active user counts, or other scale indicators
+- Observability backends in use
+
+## Why OpenTelemetry
+
+Explain the motivation behind adopting OpenTelemetry. This is not a marketing pitch, it is an honest account of what
+drove the decision to adopt OpenTelemetry.
+
+Consider:
+
+- What was the situation before OpenTelemetry? (vendor-specific agents, no instrumentation, etc.)
+- What problem or opportunity triggered the adoption?
+- Why OpenTelemetry specifically, over alternatives?
+- Were there organizational, technical, or strategic factors at play?
+
+## OpenTelemetry components in use
+
+List and briefly describe the OTel components you use, and how each fits into your architecture. Focus on the role
+each component plays, not on how to configure it (that belongs in later sections).
+
+Common components to cover (remove those that do not apply, add others as needed):
+
+- OTel SDKs (which languages, manual vs. auto-instrumentation)
+- OTel Collector (topology, role in the pipeline)
+- OTel Operator (if running on Kubernetes)
+- OTel Semantic Conventions (how you use them, any extensions or overrides)
+- Any contrib or third-party components worth highlighting
+
+### Other components
+
+Include any other OTel components, integrations, or tooling worth mentioning, e.g. OTel Operator, OpenTelemetry
+Demo, third-party receivers/exporters, etc. Remove this section if it does not apply.
+
+## Architecture
+
+Provide an overview of your end-to-end observability architecture. Diagrams are strongly encouraged. If creating
+diagrams from scratch, we RECOMMEND using Mermaid.js with default styles for consistency with the rest of the
+documentation. Alternatively, include a PNG or SVG diagram placed in the same directory as the reference
+implementation document.
+
+The goal is to give the reader a mental model of how data flows from your services to your observability backend(s).
+
+Cover:
+
+- How telemetry is emitted from services (SDK → Collector, or SDK → backend directly)
+- How the Collector (if used) is deployed and how data flows through it
+- Any processing, sampling, or enrichment that happens in the pipeline
+- Where telemetry ends up (backend(s))
+
+### Deployment and lifecycle management
+
+Explain how OTel components are deployed and kept up to date. This is particularly valuable for readers who are
+planning their own rollout.
+
+Consider:
+
+- How Collector instances are provisioned (Helm, Operator, Ansible, Terraform, etc.)
+- How configuration changes are deployed (GitOps, CI/CD pipelines, manual, etc.)
+- How you handle upgrades (frequency, process, breaking changes)
+- Any tooling that helps manage the lifecycle (e.g. OTel Operator, Argo CD)
+
+### Sampling and data governance
+
+Include this section if sampling or cost management is a relevant concern for your architecture. Remove it if it
+does not apply.
+
+Explain:
+
+- Whether you use head-based or tail-based sampling (or both)
+- Sampling rates and policies
+- How you ensure errors and high-value traces are always collected
+- Any data transformation or filtering applied in the pipeline
+
+## Configuration
+
+Share representative configuration examples. Real configurations are one of the most valuable parts of a reference
+implementation. They bridge the gap between concepts and practice.
+
+Include:
+
+- OTel SDK configuration (environment variables, config files, or programmatic setup)
+- Collector configuration (pipelines, processors, exporters)
+- Any Kubernetes manifests (OpenTelemetryCollector CRDs, etc.)
+
+Redact any secrets, API keys, or sensitive values. Use placeholders like `${ENV_VAR}`. Add comments to explain
+non-obvious choices.
+
+## Lessons and pain points
+
+This is one of the most valuable sections for readers. Be honest and specific.
+
+Consider:
+
+- What was the hardest part of the adoption journey?
+- Were there concepts that took time to understand?
+- Were there components, features, or integrations that caused unexpected friction?
+- Is there anything you would do differently if starting over?
+- Any sharp edges in the ecosystem worth flagging (with constructive context)?
+
+## Advice for others
+
+Summarize the practical lessons from your experience as actionable advice. Write this for a reader who is in a
+similar situation to where you were when you started. Bullet points work well here.
+
+## What's next
+
+Briefly describe how you plan to evolve your OpenTelemetry implementation. This gives readers a sense of where the
+journey goes from here and what problems organizations at your stage are thinking about next.

--- a/architecture/reference-implementation-template.md
+++ b/architecture/reference-implementation-template.md
@@ -5,75 +5,18 @@ linkTitle: '{Organization Name}'
 
 By [{Author Name}]({GitHub or web profile URL}) ({Organization Name}) | {Date}
 
-<!--
-This template is for documenting a reference implementation: a real-world account of how an organization has adopted OpenTelemetry in production.
-
-Unlike OTel Blueprints (which are challenge-oriented and prescriptive), reference implementations are evidence-based and narrative.
-Their purpose is to share how a specific organization approached OTel adoption, what choices they made, and what they learned.
-
-A good reference implementation tells a story. It explains:
-- Who the organization is and how it is structured.
-- What OpenTelemetry components they use and why.
-- How their architecture and configuration works in practice.
-- What worked, what didn't, and what they would do differently.
-
-IMPORTANT: This template contains sections which may not be applicable to the environment in scope, or even possible for the author to fill in.
-All sections are RECOMMENDED, helping the author drive the narrative, however the existence of any particular section is NOT REQUIRED.
-
-Two types of markup are used to guide the author:
-
-- Text in {curly brackets} denotes details that MUST be filled in by the author.
-- Text in HTML comments (like this one) contains guidance that MUST NOT appear in the final document.
-
-Authors MAY remove sections if they're not applicable to their implementation, or if they cannot share information pertaining to that section for any reason.
-Authors MAY add additional sections, diagrams, or configuration examples.
-Authors SHOULD keep descriptions factual and evidence-based, avoiding generic claims.
-Authors MUST remove all {curly bracket placeholders} and HTML comment blocks before publishing.
-Authors MAY include the names of the backend or vendor they used, but they MUST NOT include details related to why that backend was used, or the benefits/drawbacks of using it.
--->
+_Before filling in this template, read the
+[Reference Implementation authoring guidelines](./reference-implementation-guidelines.md)._
 
 ## {Organization Name} Reference Implementation
-
-<!--
-Introduce your organization in a paragraph or two.
-Explain what it does, who it serves, and any context that is relevant to understanding its observability challenges (e.g., open source product, decentralized architecture, non-profit, highly regulated industry).
-This section sets the scene.
--->
 
 {Brief description of your organization, its mission, and any architectural or operational context that is relevant to understanding its approach to observability.}
 
 ### Organizational structure
 
-<!--
-Describe how your engineering organization is structured, with a focus on who is responsible for observability.
-Be specific: a single dedicated engineer looks very different from a single 20-person platform team, or a federated structure with multiple observability teams.
-All shapes and sizes are valid, and the contrast is useful for readers in similar situations.
-
-Include relevant information such as:
-- Total engineering headcount (approximate is fine)
-- Who owns observability tooling including SDK config, Collector Gateways, etc.
-- Whether ownership is centralized or distributed across teams
-- Who is responsible for instrumentation and ultimately data emissions
-- How do observability teams interact with the rest of the organization
--->
-
 {Description of your engineering organization structure, team size, and who is responsible for observability and OpenTelemetry infrastructure.}
 
 ### Environment and scale
-
-<!--
-Describe the environment where OpenTelemetry is deployed: infrastructure, runtimes, deployment model, and scale.
-Include concrete numbers where possible.
-These help readers assess how closely their situation matches yours.
-
-Consider including:
-- Infrastructure: cloud provider(s), on-premise, hybrid
-- Orchestration: Kubernetes, VMs, serverless, etc.
-- Languages and runtimes instrumented
-- Number of services or applications
-- Request volume, active user counts, or other scale indicators
-- Observability backends in use
--->
 
 | Dimension                | Details                                              |
 |--------------------------|------------------------------------------------------|
@@ -88,32 +31,9 @@ constraints or requirements that shaped your architecture.}
 
 ## Why OpenTelemetry
 
-<!--
-Explain the motivation behind adopting OpenTelemetry.
-This is not a marketing pitch, it is an honest account of what drove the decision to adopt OpenTelemetry.
-
-Consider:
-- What was the situation before OpenTelemetry? (vendor-specific agents, no instrumentation, etc.)
-- What problem or opportunity triggered the adoption?
-- Why OpenTelemetry specifically, over alternatives?
-- Were there organizational, technical, or strategic factors at play?
--->
-
 {Explanation of why your organization chose OpenTelemetry, including the problem it solved and any alternatives considered.}
 
 ## OpenTelemetry components in use
-
-<!--
-List and briefly describe the OTel components you use, and how each fits into your architecture.
-Focus on the role each component plays, not on how to configure it (that belongs in later sections).
-
-Common components to cover (remove those that do not apply, add others as needed):
-- OTel SDKs (which languages, manual vs. auto-instrumentation)
-- OTel Collector (topology, role in the pipeline)
-- OTel Operator (if running on Kubernetes)
-- OTel Semantic Conventions (how you use them, any extensions or overrides)
-- Any contrib or third-party components worth highlighting
--->
 
 ### SDKs and instrumentation
 
@@ -126,30 +46,9 @@ If relevant, explain how SDK configuration is managed across services.}
 
 ### Other components
 
-<!--
-Include any other OTel components, integrations, or tooling worth mentioning.
-e.g. OTel Operator, OpenTelemetry Demo, third-party receivers/exporters, etc.
-Remove this section if it does not apply.
--->
-
 {Description of any other OTel components or integrations in use.}
 
 ## Architecture
-
-<!--
-Provide an overview of your end-to-end observability architecture.
-Diagrams are strongly encouraged.
-If creating diagrams from scratch, we RECOMMEND using Mermaid.js with default styles for consistency with the rest of the documentation.
-Alternatively, include a PNG or SVG diagram placed in the same directory as this file.
-
-The goal is to give the reader a mental model of how data flows from your services to your observability backend(s).
-
-Cover:
-- How telemetry is emitted from services (SDK → Collector, or SDK → backend directly)
-- How the Collector (if used) is deployed and how data flows through it
-- Any processing, sampling, or enrichment that happens in the pipeline
-- Where telemetry ends up (backend(s))
--->
 
 {High-level description of your observability architecture. Replace or supplement with a diagram.}
 
@@ -174,55 +73,15 @@ graph LR
   C2 -->|OTLP| D
 ```
 
-<!--
-Replace the diagram above with your actual architecture.
-Add stages as appropriate: DaemonSet agents, Collector gateways, sampling tiers, etc.
--->
-
 ### Deployment and lifecycle management
-
-<!--
-Explain how OTel components are deployed and kept up to date.
-This is particularly valuable for readers who are planning their own rollout.
-
-Consider:
-- How Collector instances are provisioned (Helm, Operator, Ansible, Terraform, etc.)
-- How configuration changes are deployed (GitOps, CI/CD pipelines, manual, etc.)
-- How you handle upgrades (frequency, process, breaking changes)
-- Any tooling that helps manage the lifecycle (e.g., OTel Operator, Argo CD)
--->
 
 {Explanation of how OpenTelemetry components are deployed, configured, and maintained in your environment.}
 
 ### Sampling and data governance
 
-<!--
-Include this section if sampling or cost management is a relevant concern for your architecture.
-Remove it if it does not apply.
-
-Explain:
-- Whether you use head-based or tail-based sampling (or both)
-- Sampling rates and policies
-- How you ensure errors and high-value traces are always collected
-- Any data transformation or filtering applied in the pipeline
--->
-
 {Description of your sampling strategy and how you manage telemetry data volume.}
 
 ## Configuration
-
-<!--
-Share representative configuration examples. Real configurations are one of the most valuable parts of a reference implementation.
-They bridge the gap between concepts and practice.
-
-Include:
-- OTel SDK configuration (environment variables, config files, or programmatic setup)
-- Collector configuration (pipelines, processors, exporters)
-- Any Kubernetes manifests (OpenTelemetryCollector CRDs, etc.)
-
-Redact any secrets, API keys, or sensitive values. Use placeholders like ${ENV_VAR}.
-Add comments to explain non-obvious choices.
--->
 
 ### SDK configuration
 
@@ -275,26 +134,9 @@ service:
 
 ## Lessons and pain points
 
-<!--
-This is one of the most valuable sections for readers. Be honest and specific.
-
-Consider:
-- What was the hardest part of the adoption journey?
-- Were there concepts that took time to understand?
-- Were there components, features, or integrations that caused unexpected friction?
-- Is there anything you would do differently if starting over?
-- Any sharp edges in the ecosystem worth flagging (with constructive context)?
--->
-
 {Honest account of the main difficulties encountered during OpenTelemetry adoption, including anything you would approach differently in retrospect.}
 
 ## Advice for others
-
-<!--
-Summarize the practical lessons from your experience as actionable advice.
-Write this for a reader who is in a similar situation to where you were when you started.
-Bullet points work well here.
--->
 
 Based on {Organization Name}'s experience, a few lessons stand out:
 
@@ -304,10 +146,5 @@ Based on {Organization Name}'s experience, a few lessons stand out:
 - {Add additional advice specific to your context}
 
 ## What's next
-
-<!--
-Briefly describe how you plan to evolve your OpenTelemetry implementation.
-This gives readers a sense of where the journey goes from here and what problems organizations at your stage are thinking about next.
--->
 
 {Description of planned next steps for your OpenTelemetry adoption, such as expanding instrumentation coverage, migrating to new components, contributing upstream, or onboarding additional teams.}

--- a/architecture/reference-implementation-template.md
+++ b/architecture/reference-implementation-template.md
@@ -5,8 +5,7 @@ linkTitle: '{Organization Name}'
 
 By [{Author Name}]({GitHub or web profile URL}) ({Organization Name}) | {Date}
 
-_Before filling in this template, read the
-[Reference Implementation authoring guidelines](./reference-implementation-guidelines.md)._
+_Before filling in this template, read the [Reference Implementation authoring guidelines](./reference-implementation-guidelines.md)._
 
 ## {Organization Name} Reference Implementation
 


### PR DESCRIPTION
Closes https://github.com/open-telemetry/sig-end-user/issues/348 

Changes:

* Extracted advice and guidelines in templates and formatted them as their own docs
* Extended some advice on blueprints, in particular specific recommended best practices
* Added a link in issue templates to give visibility